### PR TITLE
Fix WP_Error fatal in Gravity_API

### DIFF
--- a/src/API/class-gravity-api.php
+++ b/src/API/class-gravity-api.php
@@ -3,6 +3,7 @@ namespace Gravity_Forms\Gravity_Tools\API;
 
 use Gravity_Forms\Gravity_Tools\Model\Form_Model;
 use Gravity_Forms\Gravity_Tools\Utils\Common;
+use WP_Error;
 
 if ( ! defined( 'GRAVITY_API_URL' ) ) {
 	define( 'GRAVITY_API_URL', 'https://gravityapi.com/wp-json/gravityapi/v1' );


### PR DESCRIPTION
Fixes a WP_Error fatal happening when using Gravity_API class.