### PR TITLE
Fix str_replace deprecation notice

### DIFF
--- a/src/Updates/class-auto-updater.php
+++ b/src/Updates/class-auto-updater.php
@@ -191,7 +191,7 @@ class Auto_Updater {
 			'plugin'      => $this->_path,
 			'url'         => $this->_url,
 			'slug'        => $this->_slug,
-			'package'     => str_replace( '{KEY}', $key, $version_info['url'] ),
+			'package'     => is_string( $version_info['url'] ) ? str_replace( '{KEY}', $key, $version_info['url'] ) : '',
 			'new_version' => $version_info['version'],
 			'id'          => '0',
 		);


### PR DESCRIPTION
This PR fixes a `str_replace` deprecation notice when the 3rd parameter passed is `null`.