### PR TITLE
Add update icon support to updater class

### DIFF
--- a/src/Updates/class-auto-updater.php
+++ b/src/Updates/class-auto-updater.php
@@ -14,6 +14,7 @@ class Auto_Updater {
 	protected $_version;
 	protected $_slug;
 	protected $_title;
+	protected $_update_icon;
 	protected $_full_path;
 	protected $_path;
 	protected $_url;
@@ -29,13 +30,14 @@ class Auto_Updater {
 	protected $license_connector;
 
 
-	public function __construct( $slug, $version, $title, $full_path, $path, $url, $common, $license_connector ) {
+	public function __construct( $slug, $version, $title, $full_path, $path, $url, $update_icon, $common, $license_connector ) {
 		$this->_slug             = $slug;
 		$this->_version          = $version;
 		$this->_title            = $title;
 		$this->_full_path        = $full_path;
 		$this->_path             = $path;
 		$this->_url              = $url;
+		$this->_update_icon      = $update_icon;
 		$this->common            = $common;
 		$this->license_connector = $license_connector;
 	}
@@ -191,6 +193,9 @@ class Auto_Updater {
 			'plugin'      => $this->_path,
 			'url'         => $this->_url,
 			'slug'        => $this->_slug,
+			'icons' => array(
+				'2x' => $this->_update_icon,
+			),
 			'package'     => is_string( $version_info['url'] ) ? str_replace( '{KEY}', $key, $version_info['url'] ) : '',
 			'new_version' => $version_info['version'],
 			'id'          => '0',


### PR DESCRIPTION
This pr adds support for icons in the updater class. Should I add it to the premium updates area as well? Other places? Should I make it optional?  I decided to add it in the middle of the args to the constructor, as smtp is the only use.