### PR TITLE
Restrict update check to once per day

### DIFF
--- a/src/Updates/class-auto-updater.php
+++ b/src/Updates/class-auto-updater.php
@@ -177,6 +177,11 @@ class Auto_Updater {
 			return $option;
 		}
 
+		// Only run our check once per day.
+		if ( ( (int) time() - (int) $option->last_checked ) <= DAY_IN_SECONDS ) {
+			return $option;
+		}
+
 		$key = $this->get_key();
 
 		$version_info = $this->get_version_info( $this->_slug );


### PR DESCRIPTION
We weren't checking the last_run value before making our API calls to check for update data. This fix ensures that we only ever check it once per day.