### PR TITLE
Add in filter for check license params

### DIFF
--- a/src/API/class-gravity-api.php
+++ b/src/API/class-gravity-api.php
@@ -154,6 +154,13 @@ class Gravity_Api {
 			'is_multisite' => is_multisite(),
 		);
 
+		/**
+		 * Allow the params passed to check_license to be modified before sending.
+		 *
+		 * @since 1.0
+		 */
+		$params = apply_filters( 'gravity_api_check_license_params', $params );
+
 		$resource = 'licenses/' . $key . '/check?' . build_query( $params );
 		$result   = $this->request( $resource, null );
 		$result   = $this->prepare_response_body( $result, true );


### PR DESCRIPTION
This PR adds in a filter before doing a license check which allows the params sent to be modified. This is used [here](https://github.com/gravityforms/gravitysmtp/pull/104) to add product_code.